### PR TITLE
Julie branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Ignore the dataset folder
 yelp_dataset/
+parquet/
 
 # Ignore system files
 .DS_Store

--- a/read_yelp_user_parquet.py
+++ b/read_yelp_user_parquet.py
@@ -1,0 +1,61 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+import time
+
+PARQUET_DIR = "parquet/yelp_user"   # folder you wrote earlier
+YEARS = None                         # e.g., YEARS = [2010, 2011, 2012]  or None for all
+
+def main():
+    t0 = time.time()
+    spark = (
+        SparkSession.builder
+        .appName("ReadYelpUserParquet")
+        .config("spark.driver.memory", "4g")  # reading is lighter; bump if needed
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    # 1) Load
+    if YEARS is None:
+        # Loads all partitions
+        df = spark.read.parquet(PARQUET_DIR)
+    else:
+        # Partition-pruned load (reads only the folders matching these years)
+        paths = [f"{PARQUET_DIR}/yelping_year={y}" for y in YEARS]
+        df = spark.read.parquet(*paths)
+
+    # 2) Inspect
+    print("\nSchema:")
+    df.printSchema()
+
+    # Partition column may come in as int; if missing (non-partitioned data), this is a no-op
+    if "yelping_year" in df.columns:
+        # Optional: filter again at query-time (also prunes if not already pruned)
+        if YEARS is not None:
+            df = df.filter(col("yelping_year").isin(YEARS))
+
+    # Show how many tasks we’re using
+    print(f"\nInput partitions: {df.rdd.getNumPartitions()}")
+
+    # Count rows (forces read)
+    t1 = time.time()
+    n = df.count()
+    t2 = time.time()
+    print(f"\nRows: {n:,}")
+    print(f"Load+count time: {(t2 - t0)/60:.2f} min (count took {(t2 - t1):.1f}s)")
+
+    # 3) Quick sample peek
+    print("\nSample rows:")
+    df.select(
+        *[c for c in ["user_id","name","yelping_since","review_count","average_stars","yelping_year","fans"] if c in df.columns]
+    ).show(10, truncate=False)
+
+    # 4) Example: only recent users
+    if "yelping_year" in df.columns:
+        recent = df.filter(col("yelping_year") >= 2015)
+        print(f"\nRecent users (>=2015): {recent.count():,}")
+
+    spark.stop()
+
+if __name__ == "__main__":
+    main()

--- a/yelp_user.py
+++ b/yelp_user.py
@@ -1,0 +1,62 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, to_timestamp, year
+import os, time
+
+INPUT  = "yelp_dataset/yelp_academic_dataset_user.json"
+OUTPUT = "parquet/yelp_user"   # will be created/overwritten
+
+def main():
+    t0 = time.time()
+    cores = max(1, os.cpu_count() or 4)
+
+    spark = (
+        SparkSession.builder
+        .appName("YelpUser->Parquet")
+        # reading large JSON locally
+        .config("spark.driver.memory", "8g")
+        .config("spark.local.dir", "/tmp")
+        # parallel read: ~128 MB input splits
+        .config("spark.sql.files.maxPartitionBytes", "128m")
+        # reasonable shuffle parallelism
+        .config("spark.sql.shuffle.partitions", str(max(200, cores * 3)))
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        # parquet
+        .config("spark.sql.parquet.compression.codec", "snappy")
+        .config("spark.sql.parquet.mergeSchema", "false")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    df = spark.read.json(INPUT)
+
+    # derive year for partitioning
+    df2 = (
+        df.withColumn("yelping_since_ts", to_timestamp(col("yelping_since")))
+          .withColumn("yelping_year", year(col("yelping_since_ts")))
+    )
+
+    # keep all original columns + derived
+    all_cols = df.columns + ["yelping_since_ts", "yelping_year"]
+    out = df2.select(*[c for c in all_cols if c in df2.columns])
+
+    # Ensure rows for the same year tend to land together
+    # (total partition count = spark.sql.shuffle.partitions)
+    out = out.repartition("yelping_year")
+
+    # Cap records per parquet file so each file stays reasonably sized.
+    # Adjust up/down depending on row width (200k is a sensible default).
+    (out.write
+        .mode("overwrite")
+        .option("maxRecordsPerFile", 200_000)
+        .partitionBy("yelping_year")
+        .parquet(OUTPUT)
+    )
+
+    elapsed = time.time() - t0
+    print(f"Wrote Parquet to: {OUTPUT}")
+    print(f"Total time: {elapsed/60:.2f} minutes ({elapsed:.1f} seconds)")
+
+    spark.stop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
yelp_user.py
- splits into ~128 MB input partitions (≈32 splits for a 4 GB file)
- shuffle and creates new partitions keyed by year
- write into per-year folders in Parquet format (binary + compressed), with each file capped at ~200k rows

read_yelp_user_parquet.py
- load all parquet files
- read & filter